### PR TITLE
Upgrading to scalajs 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,6 @@ lazy val sloth = crossProject(JSPlatform, JVMPlatform)
       Deps.chameleon.value ::
 
       Deps.kittens.value % Test ::
-      Deps.boopickle.value % Test ::
       Deps.circe.core.value % Test ::
       Deps.circe.generic.value % Test ::
       Deps.circe.parser.value % Test ::

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+// shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
 organization in Global := "com.github.cornerman"
 version in Global := "0.2.1-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,8 @@ lazy val root = (project in file("."))
     skip in publish := true
   )
 
-lazy val sloth = crossProject.crossType(CrossType.Pure)
+lazy val sloth = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
   .settings(commonSettings)
   .settings(
     name := "sloth",

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -7,7 +7,7 @@ object Deps {
 
   val scalaReflect = dep("org.scala-lang" % "scala-reflect")
   val cats = dep("org.typelevel" %%% "cats-core" % "2.1.1")
-  val chameleon = dep("com.github.cornerman" %%% "chameleon" % "0.2.0")
+  val chameleon = dep("com.github.cornerman" %%% "chameleon" % "0.3.0")
 
   val scalaTest = dep("org.scalatest" %%% "scalatest" % "3.1.2")
   val kittens = dep("org.typelevel" %%% "kittens" % "2.1.0")

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -13,7 +13,7 @@ object Deps {
   val kittens = dep("org.typelevel" %%% "kittens" % "2.0.0")
   val boopickle = dep("io.suzaku" %%% "boopickle" % "1.3.1")
   val circe = new {
-    private val version = "0.12.1"
+    private val version = "0.13.0"
     val core = dep("io.circe" %%% "circe-core" % version)
     val generic = dep("io.circe" %%% "circe-generic" % version)
     val parser = dep("io.circe" %%% "circe-parser" % version)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,7 +10,7 @@ object Deps {
   val chameleon = dep("com.github.cornerman" %%% "chameleon" % "0.2.0")
 
   val scalaTest = dep("org.scalatest" %%% "scalatest" % "3.1.2")
-  val kittens = dep("org.typelevel" %%% "kittens" % "2.0.0")
+  val kittens = dep("org.typelevel" %%% "kittens" % "2.1.0")
   val boopickle = dep("io.suzaku" %%% "boopickle" % "1.3.1")
   val circe = new {
     private val version = "0.13.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/sloth/src/test/scala/SlothSpec.scala
+++ b/sloth/src/test/scala/SlothSpec.scala
@@ -6,17 +6,14 @@ import scala.util.control.NonFatal
 import sloth._
 import cats.implicits._
 
-import chameleon.ext.boopickle._
-import boopickle.Default._
 import java.nio.ByteBuffer
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.must.Matchers
-// import chameleon.ext.circe._
-// import io.circe._, io.circe.syntax._, io.circe.generic.auto._
+import chameleon.ext.circe._
+import io.circe._, io.circe.syntax._, io.circe.generic.auto._
 
 object Pickling {
-  type PickleType = ByteBuffer
-  // type PickleType = String
+  type PickleType = String
 }
 import Pickling._
 


### PR DESCRIPTION
Updated to use sbt-scalajs since `crossProject` as deprecated and removed
after `scala.js-0.6.x`

Updated to circe `0.13.0`, first release supporting scalajs 1.0.0.

Still have to upgrade boopickle once it's released for scalajs 1.0.0.
https://github.com/suzaku-io/boopickle/pull/118

Closes https://github.com/cornerman/sloth/pull/50
