### PR TITLE
Support contravariant result types in Client

### DIFF
--- a/sloth/src/main/scala/Client.scala
+++ b/sloth/src/main/scala/Client.scala
@@ -2,17 +2,26 @@ package sloth
 
 import sloth.internal.TraitMacro
 
-//TODO: move implicits to wire method
-class Client[PickleType, Result[_]](
+class ClientCo[PickleType, Result[_]](
   private[sloth] val transport: RequestTransport[PickleType, Result],
   private[sloth] val logger: LogHandler[Result]
-)(implicit private[sloth] val failureHandler: ClientFailureHandler[PickleType, Result]) {
+)(implicit private[sloth] val failureHandler: ClientHandler[Result]) {
 
   def wire[T]: T = macro TraitMacro.impl[T, PickleType, Result]
 }
 
+class ClientContra[PickleType, Result[_]](
+  private[sloth] val transport: RequestTransport[PickleType, Result],
+  private[sloth] val logger: LogHandler[Result]
+)(implicit private[sloth] val failureHandler: ClientContraHandler[Result]) {
+
+  def wire[T]: T = macro TraitMacro.implContra[T, PickleType, Result]
+}
+
 object Client {
-  def apply[PickleType, Result[_]](transport: RequestTransport[PickleType, Result], logger: LogHandler[Result] = LogHandler.empty[Result])(implicit failureHandler: ClientFailureHandler[PickleType, Result]) = new Client[PickleType, Result](transport, logger)
+  def apply[PickleType, Result[_]](transport: RequestTransport[PickleType, Result], logger: LogHandler[Result] = LogHandler.empty[Result])(implicit failureHandler: ClientHandler[Result]) = new ClientCo[PickleType, Result](transport, logger)
+
+  def contra[PickleType, Result[_]](transport: RequestTransport[PickleType, Result], logger: LogHandler[Result] = LogHandler.empty[Result])(implicit failureHandler: ClientContraHandler[Result]) = new ClientContra[PickleType, Result](transport, logger)
 }
 
 trait RequestTransport[PickleType, Result[_]] { transport =>

--- a/sloth/src/main/scala/Client.scala
+++ b/sloth/src/main/scala/Client.scala
@@ -2,22 +2,17 @@ package sloth
 
 import sloth.internal.TraitMacro
 
-import cats.MonadError
-
 //TODO: move implicits to wire method
-class Client[PickleType, Result[_], ErrorType](
+class Client[PickleType, Result[_]](
   private[sloth] val transport: RequestTransport[PickleType, Result],
   private[sloth] val logger: LogHandler[Result]
-)(implicit
-  private[sloth] val monad: MonadError[Result, _ >: ErrorType],
-  private[sloth] val failureConverter: ClientFailureConvert[ErrorType]
-) {
+)(implicit private[sloth] val failureHandler: ClientFailureHandler[PickleType, Result]) {
 
-  def wire[T]: T = macro TraitMacro.impl[T, PickleType, Result, ErrorType]
+  def wire[T]: T = macro TraitMacro.impl[T, PickleType, Result]
 }
 
 object Client {
-  def apply[PickleType, Result[_], ErrorType : ClientFailureConvert](transport: RequestTransport[PickleType, Result], logger: LogHandler[Result] = LogHandler.empty[Result])(implicit monad: MonadError[Result, _ >: ErrorType]) = new Client[PickleType, Result, ErrorType](transport, logger)
+  def apply[PickleType, Result[_]](transport: RequestTransport[PickleType, Result], logger: LogHandler[Result] = LogHandler.empty[Result])(implicit failureHandler: ClientFailureHandler[PickleType, Result]) = new Client[PickleType, Result](transport, logger)
 }
 
 trait RequestTransport[PickleType, Result[_]] { transport =>

--- a/sloth/src/main/scala/ClientHandler.scala
+++ b/sloth/src/main/scala/ClientHandler.scala
@@ -1,0 +1,33 @@
+package sloth
+
+trait ClientHandler[F[_]] {
+  def raiseFailure[B](failure: ClientFailure): F[B]
+  def eitherMap[A,B](fa: F[A])(f: A => Either[ClientFailure, B]): F[B]
+}
+object ClientHandler {
+  import cats.MonadError
+
+  implicit def monadError[F[_], ErrorType](implicit me: MonadError[F, ErrorType], c: ClientFailureConvert[ErrorType]): ClientHandler[F] = new ClientHandler[F] {
+    override def raiseFailure[B](failure: ClientFailure): F[B] = me.raiseError(c.convert(failure))
+    override def eitherMap[A,B](fa: F[A])(f: A => Either[ClientFailure, B]): F[B] = me.flatMap(fa)(pt => f(pt).fold(raiseFailure(_), me.pure(_)))
+  }
+}
+
+trait ClientContraHandler[F[_]] {
+  def raiseFailure[B](failure: ClientFailure): F[B]
+  def contramap[A,B](response: F[A])(f: B => A): F[B]
+}
+object ClientContraHandler {
+  import cats.ApplicativeError
+  import cats.data.Kleisli
+
+  implicit def applicativeErrorKleisli[R, F[_], ErrorType](implicit me: ApplicativeError[F, ErrorType], c: ClientFailureConvert[ErrorType]): ClientContraHandler[Kleisli[F, *, R]] = new ClientContraHandler[Kleisli[F, *, R]] {
+    override def raiseFailure[B](failure: ClientFailure): Kleisli[F,B,R] = Kleisli.liftF(me.raiseError(c.convert(failure)))
+    override def contramap[A,B](fa: Kleisli[F,A,R])(f: B => A): Kleisli[F,B,R] = Kleisli(b => fa(f(b)))
+  }
+
+  implicit def applicativeErrorFunc[R, F[_], ErrorType](implicit me: ApplicativeError[F, ErrorType], c: ClientFailureConvert[ErrorType]): ClientContraHandler[Function1[*, F[R]]] = new ClientContraHandler[Function1[*, F[R]]] {
+    override def raiseFailure[B](failure: ClientFailure): B => F[R] = _ => me.raiseError(c.convert(failure))
+    override def contramap[A,B](fa: A => F[R])(f: B => A): B => F[R] = b => fa(f(b))
+  }
+}

--- a/sloth/src/main/scala/Failures.scala
+++ b/sloth/src/main/scala/Failures.scala
@@ -17,19 +17,6 @@ object ClientFailure {
 }
 case class ClientException(failure: ClientFailure) extends Exception(failure.toString)
 
-trait ClientFailureHandler[PickleType, F[_]] {
-  def raiseFailure[B](failure: ClientFailure): F[B]
-  def eitherMap[B](fa: F[PickleType])(f: PickleType => Either[ClientFailure, B]): F[B]
-}
-object ClientFailureHandler {
-  import cats.MonadError
-
-  implicit def monadError[PickleType, F[_], ErrorType](implicit me: MonadError[F, ErrorType], c: ClientFailureConvert[ErrorType]): ClientFailureHandler[PickleType, F] = new ClientFailureHandler[PickleType, F] {
-    override def raiseFailure[B](failure: ClientFailure): F[B] = me.raiseError(c.convert(failure))
-    override def eitherMap[B](fa: F[PickleType])(f: PickleType => Either[ClientFailure, B]): F[B] = me.flatMap(fa)(pt => f(pt).fold(raiseFailure(_), me.pure(_)))
-  }
-}
-
 trait ClientFailureConvert[+T] {
   def convert(failure: ClientFailure): T
 }

--- a/sloth/src/main/scala/Failures.scala
+++ b/sloth/src/main/scala/Failures.scala
@@ -7,14 +7,30 @@ object ServerFailure {
   case class DeserializerError(ex: Throwable) extends ServerFailure
 }
 
-sealed trait ClientFailure
+sealed trait ClientFailure {
+  def toException = ClientException(this)
+}
 object ClientFailure {
   case class TransportError(ex: Throwable) extends ClientFailure
   case class DeserializerError(ex: Throwable) extends ClientFailure
+
 }
 case class ClientException(failure: ClientFailure) extends Exception(failure.toString)
 
-trait ClientFailureConvert[T] {
+trait ClientFailureHandler[PickleType, F[_]] {
+  def raiseFailure[B](failure: ClientFailure): F[B]
+  def eitherMap[B](fa: F[PickleType])(f: PickleType => Either[ClientFailure, B]): F[B]
+}
+object ClientFailureHandler {
+  import cats.MonadError
+
+  implicit def monadError[PickleType, F[_], ErrorType](implicit me: MonadError[F, ErrorType], c: ClientFailureConvert[ErrorType]): ClientFailureHandler[PickleType, F] = new ClientFailureHandler[PickleType, F] {
+    override def raiseFailure[B](failure: ClientFailure): F[B] = me.raiseError(c.convert(failure))
+    override def eitherMap[B](fa: F[PickleType])(f: PickleType => Either[ClientFailure, B]): F[B] = me.flatMap(fa)(pt => f(pt).fold(raiseFailure(_), me.pure(_)))
+  }
+}
+
+trait ClientFailureConvert[+T] {
   def convert(failure: ClientFailure): T
 }
 object ClientFailureConvert {
@@ -22,6 +38,6 @@ object ClientFailureConvert {
     override def convert(failure: ClientFailure) = failure
   }
   implicit def ToClientException: ClientFailureConvert[ClientException] = new ClientFailureConvert[ClientException] {
-    override def convert(failure: ClientFailure) = ClientException(failure)
+    override def convert(failure: ClientFailure) = failure.toException
   }
 }

--- a/sloth/src/main/scala/internal/Impls.scala
+++ b/sloth/src/main/scala/internal/Impls.scala
@@ -23,22 +23,35 @@ class RouterImpl[PickleType, Result[_] : Functor] {
   }
 }
 
-class ClientImpl[PickleType, Result[_]](client: Client[PickleType, Result]) {
-  import client._
+class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
   def execute[T, R](path: List[String], arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializer.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
-    val result: Result[R] = Try(transport(request)) match {
-      case Success(response) => failureHandler.eitherMap(response) { response =>
+    val result: Result[R] = Try(client.transport(request)) match {
+      case Success(response) => client.failureHandler.eitherMap(response) { response =>
         deserializer.deserialize(response) match {
           case Right(value) => Right(value)
           case Left(t) => Left(ClientFailure.DeserializerError(t))
         }
       }
-      case Failure(t) => failureHandler.raiseFailure(ClientFailure.TransportError(t))
+      case Failure(t) => client.failureHandler.raiseFailure(ClientFailure.TransportError(t))
     }
 
-    logger.logRequest[R](path, arguments, result)
+    client.logger.logRequest[R](path, arguments, result)
+  }
+}
+
+class ClientContraImpl[PickleType, Result[_]](client: ClientContra[PickleType, Result]) {
+
+  def execute[T, R](path: List[String], arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
+    val serializedArguments = serializerT.serialize(arguments)
+    val request: Request[PickleType] = Request(path, serializedArguments)
+    val result: Result[R] = Try(client.transport(request)) match {
+      case Success(response) => client.failureHandler.contramap(response)(serializerR.serialize(_))
+      case Failure(t) => client.failureHandler.raiseFailure(ClientFailure.TransportError(t))
+    }
+
+    client.logger.logRequest[R](path, arguments, result)
   }
 }

--- a/sloth/src/main/scala/internal/Macros.scala
+++ b/sloth/src/main/scala/internal/Macros.scala
@@ -99,7 +99,7 @@ object Translator {
 }
 
 object TraitMacro {
-  def impl[Trait, PickleType, Result[_], ErrorType]
+  def impl[Trait, PickleType, Result[_]]
     (c: Context)
     (implicit traitTag: c.WeakTypeTag[Trait], resultTag: c.WeakTypeTag[Result[_]]): c.Expr[Trait] = Translator(c) { t =>
     import c.universe._

--- a/sloth/src/test/scala/ImplsSpec.scala
+++ b/sloth/src/test/scala/ImplsSpec.scala
@@ -48,7 +48,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
 
     "works" in {
       val successTransport = RequestTransport[PickleType, EitherResult](request => Right(request.payload))
-      val client = Client[PickleType, EitherResult, ClientFailure](successTransport)
+      val client = Client[PickleType, EitherResult](successTransport)
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
@@ -60,7 +60,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
     "catch exception" in {
       val exception = new Exception("meh")
       val failureTransport = RequestTransport[PickleType, EitherResult](_ => throw exception)
-      val client = Client[PickleType, EitherResult, ClientFailure](failureTransport)
+      val client = Client[PickleType, EitherResult](failureTransport)
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)

--- a/sloth/src/test/scala/SlothSpec.scala
+++ b/sloth/src/test/scala/SlothSpec.scala
@@ -87,7 +87,7 @@ class SlothSpec extends AsyncFreeSpec with Matchers {
         }
       }
 
-      val client = Client[PickleType, Future, ClientException](Transport)
+      val client = Client[PickleType, Future](Transport)
       val api = client.wire[Api[Future]]
       val singleApi = client.wire[SingleApi]
       val emptyApi = client.wire[EmptyApi]
@@ -107,9 +107,7 @@ class SlothSpec extends AsyncFreeSpec with Matchers {
     case class SlothServerError(failure: ServerFailure) extends ApiError
     case class UnexpectedError(msg: String) extends ApiError
 
-    implicit def clientFailureConvert = new ClientFailureConvert[ApiError] {
-      def convert(failure: ClientFailure) = SlothClientError(failure)
-    }
+    implicit def clientFailureConvert: ClientFailureConvert[ApiError] = SlothClientError(_)
 
     type ClientResult[T] = EitherT[Future, ApiError, T]
 
@@ -128,7 +126,7 @@ class SlothSpec extends AsyncFreeSpec with Matchers {
           })
       }
 
-      val client = Client[PickleType, ClientResult, ApiError](Transport)
+      val client = Client[PickleType, ClientResult](Transport)
       val api = client.wire[Api[ClientResult]]
     }
 
@@ -150,7 +148,7 @@ class SlothSpec extends AsyncFreeSpec with Matchers {
           Backend.router(request).toEither.fold(err => Future.failed(new Exception(err.toString)), _(10).result)
       }
 
-      val client = Client[PickleType, Future, ClientException](Transport)
+      val client = Client[PickleType, Future](Transport)
       val api = client.wire[Api[Future]]
     }
 


### PR DESCRIPTION
This allows you to generate a `Client` for a contravariant type like `Kleisli` or `Function` and so on.

Use-case/Example:
```scala
trait Api[F[_]] {
  def fun(str: String): F[Int]
}

val client = Client.contra[PickleType, Kleisli[IO, *, Unit]](myTransport)
val api = client.wire[Api[Kleisli[IO, *, Unit]]]

api.fun("hallo").apply(1): IO[Unit]
```