### PR TITLE
generate String comparison instead of HashMap for Router and use Method data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ val router = Router[ByteBuffer, Future].route[Api](ApiImpl)
 
 Use it to route requests to your Api implementation:
 ```scala
-val result = router(Request[ByteBuffer](Method(apiName = "Api", methodName = "fun"), bytes))
+val result = router(Request[ByteBuffer](Method(traitName = "Api", methodName = "fun"), bytes))
 // Now result contains the serialized Int result returned by the method ApiImpl.fun
 ```
 
@@ -223,7 +223,7 @@ In the above examples, we used the type `ByteBuffer` to select the serialization
 
 Sloth derives all information about an API from a scala trait. For example:
 ```scala
-// @Name("apiName")
+// @Name("traitName")
 trait Api {
     // @Name("funName")
     def fun(a: Int, b: String)(c: Double): F[Int]
@@ -240,7 +240,7 @@ When calling `router.route[Api](impl)`, a macro generates a function that maps a
 
 ```scala
 { (method: sloth.Method) =>
-  if (method.apiName = "Api") method.methodName match {
+  if (method.traitName = "Api") method.methodName match {
     case "fun" => Some({ payload =>
         // deserialize payload
         // call Api implementation impl with arguments

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ val router = Router[PickleType, ServerResult](MyLogHandler)
 
 ### Method overloading
 
-When overloading methods with different parameter lists, sloth cannot have uniquely identify the method (because it is referenced with the trait name and the method name). Here you will need to provide a custom name:
+When overloading methods with different parameter lists, sloth cannot uniquely identify the method (because it is referenced with the trait name and the method name). Here you will need to provide a custom name:
 ```scala
 trait Api {
     def fun(i: Int): F[Int]
@@ -236,7 +236,7 @@ For each declared method in this trait (in this case `fun`):
 
 ### Server
 
-When calling `router.route[Api](impl)`, a macro generates a function that maps a method method and the pickled arguments to a pickled result. This basically boils down to:
+When calling `router.route[Api](impl)`, a macro generates a function that maps a method (trait-name + method-name) and the pickled arguments to a pickled result. This basically boils down to:
 
 ```scala
 { (method: sloth.Method) =>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ val router = Router[ByteBuffer, Future].route[Api](ApiImpl)
 
 Use it to route requests to your Api implementation:
 ```scala
-val result = router(Request[ByteBuffer]("Api" :: "fun" :: Nil, bytes))
+val result = router(Request[ByteBuffer](RequestPath(apiName = "Api", methodName = "fun"), bytes))
 // Now result contains the serialized Int result returned by the method ApiImpl.fun
 ```
 
@@ -187,7 +187,7 @@ For logging, you can define a `LogHandler`, which can log each request including
 Define it when creating the `Client`:
 ```scala
 object MyLogHandler extends LogHandler[ClientResult[_]] {
-  def logRequest[T](path: List[String], argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
+  def logRequest[T](path: RequestPath, argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
 }
 
 val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
@@ -196,7 +196,7 @@ val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
 Define it when creating the `Router`:
 ```scala
 object MyLogHandler extends LogHandler[ServerResult[_]] {
-  def logRequest[T](path: List[String], argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
+  def logRequest[T](path: RequestPath, argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
 }
 
 val router = Router[PickleType, ServerResult](MyLogHandler)
@@ -231,7 +231,7 @@ trait Api {
 ```
 
 For each declared method in this trait (in this case `fun`):
-* Calculate method path: `List("Api", "fun")` (`PathName` annotations on the trait or method are taken into account).
+* Calculate method path: `RequestPath("Api", "fun")` (`PathName` annotations on the trait or method are taken into account).
 * Serialize the method parameters as a tuple: `(a, b, c)`.
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ trait Api {
 ```
 
 For each declared method in this trait (in this case `fun`):
-* Calculate method method: `Method("Api", "fun")` (`Name` annotations on the trait or method are taken into account).
+* Calculate method name: `Method("Api", "fun")` (`Name` annotations on the trait or method are taken into account).
 * Serialize the method parameters as a tuple: `(a, b, c)`.
 
 ### Server
@@ -259,7 +259,7 @@ When calling `client.wire[Api]`, a macro generates an instance of `Api` by imple
 new Api {
     def fun(a: Int, b: String)(c: Double): F[Int] = {
         // serialize arguments
-        // call RequestTransport transport with method method and arguments
+        // call RequestTransport transport with method and arguments
         // return deserialized response
     }
 }

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ When calling `router.route[Api](impl)`, a macro generates a function that maps a
 
 ```scala
 { (endpoint: sloth.Endpoint) =>
-  if (endpoint.apiName = "Api") endpoint.methodName match {
+  if (endpoint.apiName == "Api") endpoint.methodName match {
     case "fun" => Some({ payload =>
         // deserialize payload
         // call Api implementation impl with arguments

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ val router = Router[ByteBuffer, Future].route[Api](ApiImpl)
 
 Use it to route requests to your Api implementation:
 ```scala
-val result = router(Request[ByteBuffer](RequestPath(apiName = "Api", methodName = "fun"), bytes))
+val result = router(Request[ByteBuffer](Method(apiName = "Api", methodName = "fun"), bytes))
 // Now result contains the serialized Int result returned by the method ApiImpl.fun
 ```
 
@@ -187,7 +187,7 @@ For logging, you can define a `LogHandler`, which can log each request including
 Define it when creating the `Client`:
 ```scala
 object MyLogHandler extends LogHandler[ClientResult[_]] {
-  def logRequest[T](endpoint: Endpoint, argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
+  def logRequest[T](method: Method, argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
 }
 
 val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
@@ -196,7 +196,7 @@ val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
 Define it when creating the `Router`:
 ```scala
 object MyLogHandler extends LogHandler[ServerResult[_]] {
-  def logRequest[T](endpoint: Endpoint, argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
+  def logRequest[T](method: Method, argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
 }
 
 val router = Router[PickleType, ServerResult](MyLogHandler)
@@ -204,11 +204,11 @@ val router = Router[PickleType, ServerResult](MyLogHandler)
 
 ### Method overloading
 
-When overloading methods with different parameter lists, sloth does not have a unique endpoint (because it is derived from the trait name and the method name). Here you will need to provide your own endpoint name:
+When overloading methods with different parameter lists, sloth cannot have uniquely identify the method (because it is referenced with the trait name and the method name). Here you will need to provide a custom name:
 ```scala
 trait Api {
     def fun(i: Int): F[Int]
-    @EndpointName("funWithString")
+    @Name("funWithString")
     def fun(i: Int, s: String): F[Int]
 }
 ```
@@ -223,24 +223,24 @@ In the above examples, we used the type `ByteBuffer` to select the serialization
 
 Sloth derives all information about an API from a scala trait. For example:
 ```scala
-// @EndpointName("apiName")
+// @Name("apiName")
 trait Api {
-    // @EndpointName("funName")
+    // @Name("funName")
     def fun(a: Int, b: String)(c: Double): F[Int]
 }
 ```
 
 For each declared method in this trait (in this case `fun`):
-* Calculate method endpoint: `Endpoint("Api", "fun")` (`EndpointName` annotations on the trait or method are taken into account).
+* Calculate method method: `Method("Api", "fun")` (`Name` annotations on the trait or method are taken into account).
 * Serialize the method parameters as a tuple: `(a, b, c)`.
 
 ### Server
 
-When calling `router.route[Api](impl)`, a macro generates a function that maps a method endpoint and the pickled arguments to a pickled result. This basically boils down to:
+When calling `router.route[Api](impl)`, a macro generates a function that maps a method method and the pickled arguments to a pickled result. This basically boils down to:
 
 ```scala
-{ (endpoint: sloth.Endpoint) =>
-  if (endpoint.apiName == "Api") endpoint.methodName match {
+{ (method: sloth.Method) =>
+  if (method.apiName = "Api") method.methodName match {
     case "fun" => Some({ payload =>
         // deserialize payload
         // call Api implementation impl with arguments
@@ -259,7 +259,7 @@ When calling `client.wire[Api]`, a macro generates an instance of `Api` by imple
 new Api {
     def fun(a: Int, b: String)(c: Double): F[Int] = {
         // serialize arguments
-        // call RequestTransport transport with method endpoint and arguments
+        // call RequestTransport transport with method method and arguments
         // return deserialized response
     }
 }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For logging, you can define a `LogHandler`, which can log each request including
 Define it when creating the `Client`:
 ```scala
 object MyLogHandler extends LogHandler[ClientResult[_]] {
-  def logRequest[T](path: RequestPath, argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
+  def logRequest[T](endpoint: Endpoint, argumentObject: Any, result: ClientResult[T]): ClientResult[T] = ???
 }
 
 val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
@@ -196,7 +196,7 @@ val client = Client[PickleType, ClientResult](Transport, MyLogHandler)
 Define it when creating the `Router`:
 ```scala
 object MyLogHandler extends LogHandler[ServerResult[_]] {
-  def logRequest[T](path: RequestPath, argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
+  def logRequest[T](endpoint: Endpoint, argumentObject: Any, result: ServerResult[T]): ServerResult[T] = ???
 }
 
 val router = Router[PickleType, ServerResult](MyLogHandler)
@@ -204,11 +204,11 @@ val router = Router[PickleType, ServerResult](MyLogHandler)
 
 ### Method overloading
 
-When overloading methods with different parameter lists, sloth does not have a unique path (because it is derived from the trait name and the method name). Here you will need to provide your own path name:
+When overloading methods with different parameter lists, sloth does not have a unique endpoint (because it is derived from the trait name and the method name). Here you will need to provide your own endpoint name:
 ```scala
 trait Api {
     def fun(i: Int): F[Int]
-    @PathName("funWithString")
+    @EndpointName("funWithString")
     def fun(i: Int, s: String): F[Int]
 }
 ```
@@ -223,27 +223,32 @@ In the above examples, we used the type `ByteBuffer` to select the serialization
 
 Sloth derives all information about an API from a scala trait. For example:
 ```scala
-// @PathName("apiName")
+// @EndpointName("apiName")
 trait Api {
-    // @PathName("funName")
+    // @EndpointName("funName")
     def fun(a: Int, b: String)(c: Double): F[Int]
 }
 ```
 
 For each declared method in this trait (in this case `fun`):
-* Calculate method path: `RequestPath("Api", "fun")` (`PathName` annotations on the trait or method are taken into account).
+* Calculate method endpoint: `Endpoint("Api", "fun")` (`EndpointName` annotations on the trait or method are taken into account).
 * Serialize the method parameters as a tuple: `(a, b, c)`.
 
 ### Server
 
-When calling `router.route[Api](impl)`, a macro generates a function that maps a method path and the pickled arguments to a pickled result. This basically boils down to:
+When calling `router.route[Api](impl)`, a macro generates a function that maps a method endpoint and the pickled arguments to a pickled result. This basically boils down to:
 
 ```scala
-HashMap("Api" -> HashMap("fun" -> { payload =>
-    // deserialize payload
-    // call Api implementation impl with arguments
-    // return serialized response
-}))
+{ (endpoint: sloth.Endpoint) =>
+  if (endpoint.apiName = "Api") endpoint.methodName match {
+    case "fun" => Some({ payload =>
+        // deserialize payload
+        // call Api implementation impl with arguments
+        // return serialized response
+    })
+    case _ => None
+  } else None
+}
 ```
 
 ### Client
@@ -254,7 +259,7 @@ When calling `client.wire[Api]`, a macro generates an instance of `Api` by imple
 new Api {
     def fun(a: Int, b: String)(c: Double): F[Int] = {
         // serialize arguments
-        // call RequestTransport transport with method path and arguments
+        // call RequestTransport transport with method endpoint and arguments
         // return deserialized response
     }
 }

--- a/http4sClient/src/main/scala/HttpRpcTransport.scala
+++ b/http4sClient/src/main/scala/HttpRpcTransport.scala
@@ -13,7 +13,7 @@ case class HttpRequestConfig(
 ) {
   def toRequest[F[_]](method: sloth.Method, entityBody: EntityBody[F]): Request[F] = Request[F](
     method = Method.POST,
-    uri = baseUri / method.apiName / method.methodName,
+    uri = baseUri / method.traitName / method.methodName,
     httpVersion = httpVersion,
     headers = headers,
     body = entityBody,

--- a/http4sClient/src/main/scala/HttpRpcTransport.scala
+++ b/http4sClient/src/main/scala/HttpRpcTransport.scala
@@ -5,16 +5,16 @@ import cats.implicits._
 import org.http4s.client.Client
 import org.http4s.{EntityBody, EntityDecoder, EntityEncoder, Headers, HttpVersion, Method, Request, ServerSentEvent, Uri}
 import fs2.Stream
-import sloth.RequestTransport
+import sloth.{RequestPath, RequestTransport}
 
 case class HttpRequestConfig(
   baseUri: Uri = Uri(path = Uri.Path.Root),
   headers: Headers = Headers.empty,
   httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
 ) {
-  def toRequest[F[_]](requestPath: List[String], entityBody: EntityBody[F]): Request[F] = Request[F](
+  def toRequest[F[_]](requestPath: RequestPath, entityBody: EntityBody[F]): Request[F] = Request[F](
     method = Method.POST,
-    uri = requestPath.foldLeft(baseUri)(_ / _),
+    uri = baseUri / requestPath.apiName / requestPath.methodName,
     httpVersion = httpVersion,
     headers = headers,
     body = entityBody,

--- a/http4sClient/src/main/scala/HttpRpcTransport.scala
+++ b/http4sClient/src/main/scala/HttpRpcTransport.scala
@@ -5,16 +5,15 @@ import cats.implicits._
 import org.http4s.client.Client
 import org.http4s.{EntityBody, EntityDecoder, EntityEncoder, Headers, HttpVersion, Method, Request, ServerSentEvent, Uri}
 import fs2.Stream
-import sloth.{Endpoint, RequestTransport}
 
 case class HttpRequestConfig(
   baseUri: Uri = Uri(path = Uri.Path.Root),
   headers: Headers = Headers.empty,
   httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
 ) {
-  def toRequest[F[_]](endpoint: Endpoint, entityBody: EntityBody[F]): Request[F] = Request[F](
+  def toRequest[F[_]](method: sloth.Method, entityBody: EntityBody[F]): Request[F] = Request[F](
     method = Method.POST,
-    uri = baseUri / endpoint.apiName / endpoint.methodName,
+    uri = baseUri / method.apiName / method.methodName,
     httpVersion = httpVersion,
     headers = headers,
     body = entityBody,
@@ -27,7 +26,7 @@ object HttpRpcTransport {
    )(implicit
      encoder: EntityEncoder[F, PickleType],
      decoder: EntityDecoder[F, PickleType]
-   ): RequestTransport[PickleType, F] = apply(client, HttpRequestConfig().pure[F])
+   ): sloth.RequestTransport[PickleType, F] = apply(client, HttpRequestConfig().pure[F])
 
   def apply[PickleType, F[_]: Concurrent](
      client: Client[F],
@@ -35,24 +34,24 @@ object HttpRpcTransport {
    )(implicit
      encoder: EntityEncoder[F, PickleType],
      decoder: EntityDecoder[F, PickleType]
-  ): RequestTransport[PickleType, F] = new sloth.RequestTransport[PickleType, F] {
+  ): sloth.RequestTransport[PickleType, F] = new sloth.RequestTransport[PickleType, F] {
     override def apply(request: sloth.Request[PickleType]): F[PickleType] = for {
       config <- config
-      responseBody <- client.expect[PickleType](config.toRequest(request.endpoint, encoder.toEntity(request.payload).body))
+      responseBody <- client.expect[PickleType](config.toRequest(request.method, encoder.toEntity(request.payload).body))
     } yield responseBody
   }
 
   def eventStream[F[_]: Concurrent](
     client: Client[F],
-  ): RequestTransport[String, Stream[F, *]] = eventStream(client, HttpRequestConfig().pure[F])
+  ): sloth.RequestTransport[String, Stream[F, *]] = eventStream(client, HttpRequestConfig().pure[F])
 
   def eventStream[F[_]: Concurrent](
     client: Client[F],
     config: F[HttpRequestConfig]
-  ): RequestTransport[String, Stream[F, *]] = new sloth.RequestTransport[String, Stream[F, *]] {
+  ): sloth.RequestTransport[String, Stream[F, *]] = new sloth.RequestTransport[String, Stream[F, *]] {
     override def apply(request: sloth.Request[String]): Stream[F, String] = for {
       config <- Stream.eval(config)
-      response <- Stream.resource(client.run(config.toRequest(request.endpoint, EntityEncoder[F, String].toEntity(request.payload).body)))
+      response <- Stream.resource(client.run(config.toRequest(request.method, EntityEncoder[F, String].toEntity(request.payload).body)))
       event <- response.body.through(ServerSentEvent.decoder[F])
       data <- Stream.fromOption(event.data)
     } yield data

--- a/http4sServer/src/main/scala/HttpRpcRoutes.scala
+++ b/http4sServer/src/main/scala/HttpRpcRoutes.scala
@@ -6,7 +6,7 @@ import cats.effect.Concurrent
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import fs2.Stream
-import sloth.{Router, ServerFailure}
+import sloth.{RequestPath, Router, ServerFailure}
 
 object HttpRpcRoutes {
 
@@ -25,7 +25,7 @@ object HttpRpcRoutes {
     HttpRoutes[F] { request =>
         request.pathInfo.segments match {
           case Vector(apiName, methodName) =>
-            val path = List(apiName.decoded(), methodName.decoded())
+            val path = RequestPath(apiName.decoded(), methodName.decoded())
             val result = router(request).getFunction(path).traverse { f =>
               request.as[PickleType].flatMap { payload =>
                 f(payload) match {
@@ -56,7 +56,7 @@ object HttpRpcRoutes {
     HttpRoutes[F] { request =>
       request.pathInfo.segments match {
         case Vector(apiName, methodName) =>
-          val path = List(apiName.decoded(), methodName.decoded())
+          val path = RequestPath(apiName.decoded(), methodName.decoded())
           val result = router(request).getFunction(path).traverse { f =>
             request.as[String].flatMap { payload =>
               f(payload) match {

--- a/http4sServer/src/main/scala/HttpRpcRoutes.scala
+++ b/http4sServer/src/main/scala/HttpRpcRoutes.scala
@@ -25,7 +25,7 @@ object HttpRpcRoutes {
         request.pathInfo.segments match {
           case Vector(traitName, methodName) =>
             val method = sloth.Method(traitName.decoded(), methodName.decoded())
-            val result = router(request).get(method).traverse { f =>
+            val result = router(request).getMethod(method).traverse { f =>
               request.as[PickleType].flatMap { payload =>
                 f(payload) match {
                   case Left(error)     => serverFailureToResponse[F](dsl, onError)(error)
@@ -56,7 +56,7 @@ object HttpRpcRoutes {
       request.pathInfo.segments match {
         case Vector(traitName, methodName) =>
           val method = sloth.Method(traitName.decoded(), methodName.decoded())
-          val result = router(request).get(method).traverse { f =>
+          val result = router(request).getMethod(method).traverse { f =>
             request.as[String].flatMap { payload =>
               f(payload) match {
                 case Left(error) => serverFailureToResponse[F](dsl, onError)(error)

--- a/http4sServer/src/main/scala/HttpRpcRoutes.scala
+++ b/http4sServer/src/main/scala/HttpRpcRoutes.scala
@@ -23,8 +23,8 @@ object HttpRpcRoutes {
 
     HttpRoutes[F] { request =>
         request.pathInfo.segments match {
-          case Vector(apiName, methodName) =>
-            val method = sloth.Method(apiName.decoded(), methodName.decoded())
+          case Vector(traitName, methodName) =>
+            val method = sloth.Method(traitName.decoded(), methodName.decoded())
             val result = router(request).get(method).traverse { f =>
               request.as[PickleType].flatMap { payload =>
                 f(payload) match {
@@ -54,8 +54,8 @@ object HttpRpcRoutes {
 
     HttpRoutes[F] { request =>
       request.pathInfo.segments match {
-        case Vector(apiName, methodName) =>
-          val method = sloth.Method(apiName.decoded(), methodName.decoded())
+        case Vector(traitName, methodName) =>
+          val method = sloth.Method(traitName.decoded(), methodName.decoded())
           val result = router(request).get(method).traverse { f =>
             request.as[String].flatMap { payload =>
               f(payload) match {

--- a/http4sServer/src/main/scala/HttpRpcRoutes.scala
+++ b/http4sServer/src/main/scala/HttpRpcRoutes.scala
@@ -6,17 +6,16 @@ import cats.effect.Concurrent
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import fs2.Stream
-import sloth.{Endpoint, Router, ServerFailure}
 
 object HttpRpcRoutes {
 
   def apply[PickleType: EntityDecoder[F, *]: EntityEncoder[F, *], F[_]: Concurrent](
-    router: Router[PickleType, F],
+    router: sloth.Router[PickleType, F],
     onError: PartialFunction[Throwable, F[Response[F]]] = PartialFunction.empty
   ): HttpRoutes[F] = withRequest[PickleType, F](_ => router, onError)
 
   def withRequest[PickleType: EntityDecoder[F, *]: EntityEncoder[F, *], F[_]: Concurrent](
-    router: Request[F] => Router[PickleType, F],
+    router: Request[F] => sloth.Router[PickleType, F],
     onError: PartialFunction[Throwable, F[Response[F]]] = PartialFunction.empty
   ): HttpRoutes[F] = {
     val dsl = Http4sDsl[F]
@@ -25,8 +24,8 @@ object HttpRpcRoutes {
     HttpRoutes[F] { request =>
         request.pathInfo.segments match {
           case Vector(apiName, methodName) =>
-            val endpoint = Endpoint(apiName.decoded(), methodName.decoded())
-            val result = router(request).get(endpoint).traverse { f =>
+            val method = sloth.Method(apiName.decoded(), methodName.decoded())
+            val result = router(request).get(method).traverse { f =>
               request.as[PickleType].flatMap { payload =>
                 f(payload) match {
                   case Left(error)     => serverFailureToResponse[F](dsl, onError)(error)
@@ -42,12 +41,12 @@ object HttpRpcRoutes {
   }
 
   def eventStream[F[_]: Concurrent](
-    router: Router[String, Stream[F, *]],
+    router: sloth.Router[String, Stream[F, *]],
     onError: PartialFunction[Throwable, F[Response[F]]] = PartialFunction.empty
   ): HttpRoutes[F] = eventStreamWithRequest[F](_ => router, onError)
 
   def eventStreamWithRequest[F[_]: Concurrent](
-    router: Request[F] => Router[String, Stream[F, *]],
+    router: Request[F] => sloth.Router[String, Stream[F, *]],
     onError: PartialFunction[Throwable, F[Response[F]]] = PartialFunction.empty
   ): HttpRoutes[F] = {
     val dsl = Http4sDsl[F]
@@ -56,8 +55,8 @@ object HttpRpcRoutes {
     HttpRoutes[F] { request =>
       request.pathInfo.segments match {
         case Vector(apiName, methodName) =>
-          val endpoint = Endpoint(apiName.decoded(), methodName.decoded())
-          val result = router(request).get(endpoint).traverse { f =>
+          val method = sloth.Method(apiName.decoded(), methodName.decoded())
+          val result = router(request).get(method).traverse { f =>
             request.as[String].flatMap { payload =>
               f(payload) match {
                 case Left(error) => serverFailureToResponse[F](dsl, onError)(error)
@@ -72,12 +71,12 @@ object HttpRpcRoutes {
     }
   }
 
-  private def serverFailureToResponse[F[_]: Concurrent](dsl: Http4sDsl[F], onError: PartialFunction[Throwable, F[Response[F]]])(failure: ServerFailure): F[Response[F]] = {
+  private def serverFailureToResponse[F[_]: Concurrent](dsl: Http4sDsl[F], onError: PartialFunction[Throwable, F[Response[F]]])(failure: sloth.ServerFailure): F[Response[F]] = {
     import dsl._
     failure match {
-      case ServerFailure.EndpointNotFound(_)    => NotFound()
-      case ServerFailure.HandlerError(err)      => onError.lift(err).getOrElse(InternalServerError(err.getMessage))
-      case ServerFailure.DeserializerError(err) => onError.lift(err).getOrElse(BadRequest(err.getMessage))
+      case sloth.ServerFailure.MethodNotFound(_)    => NotFound()
+      case sloth.ServerFailure.HandlerError(err)      => onError.lift(err).getOrElse(InternalServerError(err.getMessage))
+      case sloth.ServerFailure.DeserializerError(err) => onError.lift(err).getOrElse(BadRequest(err.getMessage))
     }
   }
 }

--- a/jsdomClient/src/main/scala/HttpRpcTransport.scala
+++ b/jsdomClient/src/main/scala/HttpRpcTransport.scala
@@ -19,7 +19,7 @@ object HttpRpcTransport {
   def apply[F[_]: Async](config: F[HttpRequestConfig]): RequestTransport[String, F] = new RequestTransport[String, F] {
     override def apply(request: Request[String]): F[String] = for {
       config <- config
-      url = s"${config.baseUri}/${request.path.apiName}/${request.path.methodName}"
+      url = s"${config.baseUri}/${request.endpoint.apiName}/${request.endpoint.methodName}"
       requestArgs = new dom.RequestInit { headers = config.headers.toJSDictionary; method = dom.HttpMethod.POST; body = request.payload }
       result <- Async[F].fromThenable(Async[F].delay[js.Thenable[String]](dom.fetch(url, requestArgs).`then`[String](_.text())))
     } yield result

--- a/jsdomClient/src/main/scala/HttpRpcTransport.scala
+++ b/jsdomClient/src/main/scala/HttpRpcTransport.scala
@@ -19,7 +19,7 @@ object HttpRpcTransport {
   def apply[F[_]: Async](config: F[HttpRequestConfig]): RequestTransport[String, F] = new RequestTransport[String, F] {
     override def apply(request: Request[String]): F[String] = for {
       config <- config
-      url = s"${config.baseUri}/${request.method.apiName}/${request.method.methodName}"
+      url = s"${config.baseUri}/${request.method.traitName}/${request.method.methodName}"
       requestArgs = new dom.RequestInit { headers = config.headers.toJSDictionary; method = dom.HttpMethod.POST; body = request.payload }
       result <- Async[F].fromThenable(Async[F].delay[js.Thenable[String]](dom.fetch(url, requestArgs).`then`[String](_.text())))
     } yield result

--- a/jsdomClient/src/main/scala/HttpRpcTransport.scala
+++ b/jsdomClient/src/main/scala/HttpRpcTransport.scala
@@ -19,7 +19,7 @@ object HttpRpcTransport {
   def apply[F[_]: Async](config: F[HttpRequestConfig]): RequestTransport[String, F] = new RequestTransport[String, F] {
     override def apply(request: Request[String]): F[String] = for {
       config <- config
-      url = s"${config.baseUri}/${request.endpoint.apiName}/${request.endpoint.methodName}"
+      url = s"${config.baseUri}/${request.method.apiName}/${request.method.methodName}"
       requestArgs = new dom.RequestInit { headers = config.headers.toJSDictionary; method = dom.HttpMethod.POST; body = request.payload }
       result <- Async[F].fromThenable(Async[F].delay[js.Thenable[String]](dom.fetch(url, requestArgs).`then`[String](_.text())))
     } yield result

--- a/jsdomClient/src/main/scala/HttpRpcTransport.scala
+++ b/jsdomClient/src/main/scala/HttpRpcTransport.scala
@@ -19,7 +19,7 @@ object HttpRpcTransport {
   def apply[F[_]: Async](config: F[HttpRequestConfig]): RequestTransport[String, F] = new RequestTransport[String, F] {
     override def apply(request: Request[String]): F[String] = for {
       config <- config
-      url = s"${config.baseUri}${request.path.mkString("/")}"
+      url = s"${config.baseUri}/${request.path.apiName}/${request.path.methodName}"
       requestArgs = new dom.RequestInit { headers = config.headers.toJSDictionary; method = dom.HttpMethod.POST; body = request.payload }
       result <- Async[F].fromThenable(Async[F].delay[js.Thenable[String]](dom.fetch(url, requestArgs).`then`[String](_.text())))
     } yield result

--- a/sloth/src/main/scala-2/internal/Macros.scala
+++ b/sloth/src/main/scala-2/internal/Macros.scala
@@ -1,7 +1,5 @@
 package sloth.internal
 
-import sloth.Method
-
 import scala.reflect.macros.blackbox.Context
 
 object Validator {
@@ -19,8 +17,8 @@ class Translator[C <: Context](val c: C) {
   import Validator._
 
   object implicits {
-    implicit val liftMethod: Liftable[Method] =
-      Liftable[Method]{ r => q"new _root_.sloth.Method(${r.traitName}, ${r.methodName})" }
+    implicit val liftMethod: Liftable[sloth.Method] =
+      Liftable[sloth.Method]{ r => q"new _root_.sloth.Method(${r.traitName}, ${r.methodName})" }
   }
 
   def abort(msg: String) = c.abort(c.enclosingPosition, msg)
@@ -138,7 +136,7 @@ object TraitMacro {
     val traitPathPart = t.traitPathPart(traitTag.tpe)
     val methodImplList = validMethods.collect { case (symbol, method) =>
       val methodPathPart = t.methodPathPart(symbol)
-      val path = Method(traitPathPart, methodPathPart)
+      val path = sloth.Method(traitPathPart, methodPathPart)
       val parameters =  t.paramsAsValDefs(method)
       val paramsType = t.paramsType(method)
       val paramListValue = t.wrapAsParamsType(method)

--- a/sloth/src/main/scala-2/internal/Macros.scala
+++ b/sloth/src/main/scala-2/internal/Macros.scala
@@ -20,7 +20,7 @@ class Translator[C <: Context](val c: C) {
 
   object implicits {
     implicit val liftMethod: Liftable[Method] =
-      Liftable[Method]{ r => q"new _root_.sloth.Method(${r.apiName}, ${r.methodName})" }
+      Liftable[Method]{ r => q"new _root_.sloth.Method(${r.traitName}, ${r.methodName})" }
   }
 
   def abort(msg: String) = c.abort(c.enclosingPosition, msg)
@@ -209,7 +209,7 @@ object RouterMacro {
       val impl = $impl
 
       implRouter.orElse { method =>
-        if (method.apiName == $traitPathPart) {
+        if (method.traitName == $traitPathPart) {
           method.methodName match {
             case ..$methodCases
             case _ => None

--- a/sloth/src/main/scala-2/internal/Macros.scala
+++ b/sloth/src/main/scala-2/internal/Macros.scala
@@ -40,11 +40,11 @@ class Translator[C <: Context](val c: C) {
   private def validateAllMethods(methods: List[(MethodSymbol, Type)]): List[Either[String, (MethodSymbol, Type)]] =
     methods.groupBy(m => methodPathPart(m._1)).map {
       case (_, x :: Nil) => Right(x)
-      case (k, _) => Left(s"""method $k is overloaded (rename the method or add a @PathName("other-name"))""")
+      case (k, _) => Left(s"""method $k is overloaded (rename the method or add a @EndpointName("other-name"))""")
     }.toList
 
-  private def findPathName(annotations: Seq[Annotation]) = annotations.reverse.map(_.tree).collectFirst {
-    case Apply(Select(New(annotation), _), Literal(Constant(name)) :: Nil) if annotation.tpe =:= typeOf[sloth.PathName] => name.toString
+  private def findEndpointName(annotations: Seq[Annotation]) = annotations.reverse.map(_.tree).collectFirst {
+    case Apply(Select(New(annotation), _), Literal(Constant(name)) :: Nil) if annotation.tpe =:= typeOf[sloth.EndpointName] => name.toString
   }
 
   private def eitherSeq[A, B](list: List[Either[A, B]]): Either[List[A], List[B]] = list.partition(_.isLeft) match {
@@ -76,10 +76,10 @@ class Translator[C <: Context](val c: C) {
 
   //TODO what about fqn for trait to not have overlaps?
   def traitPathPart(tpe: Type): String =
-    findPathName(tpe.typeSymbol.annotations).getOrElse(tpe.typeSymbol.name.toString)
+    findEndpointName(tpe.typeSymbol.annotations).getOrElse(tpe.typeSymbol.name.toString)
 
   def methodPathPart(m: MethodSymbol): String =
-    findPathName(m.annotations).getOrElse(m.name.toString)
+    findEndpointName(m.annotations).getOrElse(m.name.toString)
 
   def paramAsValDef(p: Symbol): ValDef = q"val ${p.name.toTermName}: ${p.typeSignature}"
   def paramsAsValDefs(m: Type): List[List[ValDef]] = m.paramLists.map(_.map(paramAsValDef))
@@ -120,7 +120,7 @@ class Translator[C <: Context](val c: C) {
 object Translator {
   def apply[T](c: Context)(f: Translator[c.type] => c.Tree): c.Expr[T] = {
     val tree = f(new Translator(c))
-//    println(tree)
+   println(tree)
     c.Expr(tree)
   }
 }

--- a/sloth/src/main/scala-2/internal/Macros.scala
+++ b/sloth/src/main/scala-2/internal/Macros.scala
@@ -120,7 +120,7 @@ class Translator[C <: Context](val c: C) {
 object Translator {
   def apply[T](c: Context)(f: Translator[c.type] => c.Tree): c.Expr[T] = {
     val tree = f(new Translator(c))
-   println(tree)
+   // println(tree)
     c.Expr(tree)
   }
 }

--- a/sloth/src/main/scala-3/internal/Macros.scala
+++ b/sloth/src/main/scala-3/internal/Macros.scala
@@ -221,7 +221,7 @@ object TraitMacro {
       Block(List(clsDef), newCls)
     }
 
-    println(result.show)
+    // println(result.show)
     result.asExprOf[Trait]
   }
 }

--- a/sloth/src/main/scala-3/internal/Macros.scala
+++ b/sloth/src/main/scala-3/internal/Macros.scala
@@ -10,7 +10,7 @@ import scala.quoted.runtime.StopMacroExpansion
 private implicit val toExprMethod: ToExpr[Method] = new ToExpr[Method] {
   def apply(path: Method)(using Quotes): Expr[Method] = {
     import quotes.reflect._
-    '{ Method(${Expr(path.apiName)}, ${Expr(path.methodName)}) }
+    '{ Method(${Expr(path.traitName)}, ${Expr(path.methodName)}) }
   }
 }
 
@@ -318,7 +318,7 @@ object RouterMacro {
 
       '{
         ${prefix}.orElse { method =>
-          if (method.apiName == ${Expr(traitPathPart)}) {
+          if (method.traitName == ${Expr(traitPathPart)}) {
             ${Match(
               '{method.methodName}.asTerm,
               methodCases('{method}.asTerm) :+ CaseDef(Wildcard(), None, '{ None }.asTerm)

--- a/sloth/src/main/scala-3/internal/Macros.scala
+++ b/sloth/src/main/scala-3/internal/Macros.scala
@@ -328,7 +328,7 @@ object RouterMacro {
       }.asTerm
     }
 
-    println(result.show)
+    // println(result.show)
     result.asExprOf[Router[PickleType, Result]]
   }
 }

--- a/sloth/src/main/scala/Annotations.scala
+++ b/sloth/src/main/scala/Annotations.scala
@@ -2,4 +2,4 @@ package sloth
 
 import scala.annotation.StaticAnnotation
 
-class EndpointName(val name: String) extends StaticAnnotation
+class Name(val name: String) extends StaticAnnotation

--- a/sloth/src/main/scala/Annotations.scala
+++ b/sloth/src/main/scala/Annotations.scala
@@ -2,4 +2,4 @@ package sloth
 
 import scala.annotation.StaticAnnotation
 
-class PathName(val name: String) extends StaticAnnotation
+class EndpointName(val name: String) extends StaticAnnotation

--- a/sloth/src/main/scala/Failures.scala
+++ b/sloth/src/main/scala/Failures.scala
@@ -4,7 +4,7 @@ sealed trait ServerFailure {
   def toException = ServerException(this)
 }
 object ServerFailure {
-  case class PathNotFound(path: List[String]) extends ServerFailure
+  case class PathNotFound(path: RequestPath) extends ServerFailure
   case class HandlerError(ex: Throwable) extends ServerFailure
   case class DeserializerError(ex: Throwable) extends ServerFailure
 }
@@ -17,7 +17,6 @@ sealed trait ClientFailure {
 object ClientFailure {
   case class TransportError(ex: Throwable) extends ClientFailure
   case class DeserializerError(ex: Throwable) extends ClientFailure
-
 }
 case class ClientException(failure: ClientFailure) extends Exception(failure.toString)
 

--- a/sloth/src/main/scala/Failures.scala
+++ b/sloth/src/main/scala/Failures.scala
@@ -4,9 +4,14 @@ sealed trait ServerFailure {
   def toException = ServerException(this)
 }
 object ServerFailure {
-  case class PathNotFound(path: RequestPath) extends ServerFailure
+  case class EndpointNotFound(path: Endpoint) extends ServerFailure
   case class HandlerError(ex: Throwable) extends ServerFailure
   case class DeserializerError(ex: Throwable) extends ServerFailure
+
+  @deprecated("Use EndpointNotFound instead", "0.8.0")
+  val PathNotFound = EndpointNotFound
+  @deprecated("Use EndpointNotFound instead", "0.8.0")
+  type PathNotFound = EndpointNotFound
 }
 
 case class ServerException(failure: ServerFailure) extends Exception(failure.toString)

--- a/sloth/src/main/scala/Failures.scala
+++ b/sloth/src/main/scala/Failures.scala
@@ -4,14 +4,14 @@ sealed trait ServerFailure {
   def toException = ServerException(this)
 }
 object ServerFailure {
-  case class EndpointNotFound(path: Endpoint) extends ServerFailure
+  case class MethodNotFound(path: Method) extends ServerFailure
   case class HandlerError(ex: Throwable) extends ServerFailure
   case class DeserializerError(ex: Throwable) extends ServerFailure
 
-  @deprecated("Use EndpointNotFound instead", "0.8.0")
-  val PathNotFound = EndpointNotFound
-  @deprecated("Use EndpointNotFound instead", "0.8.0")
-  type PathNotFound = EndpointNotFound
+  @deprecated("Use MethodNotFound instead", "0.8.0")
+  val PathNotFound = MethodNotFound
+  @deprecated("Use MethodNotFound instead", "0.8.0")
+  type PathNotFound = MethodNotFound
 }
 
 case class ServerException(failure: ServerFailure) extends Exception(failure.toString)

--- a/sloth/src/main/scala/LogHandler.scala
+++ b/sloth/src/main/scala/LogHandler.scala
@@ -1,10 +1,10 @@
 package sloth
 
 trait LogHandler[Result[_]] {
-  def logRequest[A, T](path: RequestPath, argumentObject: A, result: Result[T]): Result[T]
+  def logRequest[A, T](endpoint: Endpoint, argumentObject: A, result: Result[T]): Result[T]
 }
 object LogHandler {
   def empty[Result[_]]: LogHandler[Result] = new LogHandler[Result] {
-    def logRequest[A, T](path: RequestPath, argumentObject: A, result: Result[T]): Result[T] = result
+    def logRequest[A, T](endpoint: Endpoint, argumentObject: A, result: Result[T]): Result[T] = result
   }
 }

--- a/sloth/src/main/scala/LogHandler.scala
+++ b/sloth/src/main/scala/LogHandler.scala
@@ -1,10 +1,10 @@
 package sloth
 
 trait LogHandler[Result[_]] {
-  def logRequest[A, T](path: List[String], argumentObject: A, result: Result[T]): Result[T]
+  def logRequest[A, T](path: RequestPath, argumentObject: A, result: Result[T]): Result[T]
 }
 object LogHandler {
   def empty[Result[_]]: LogHandler[Result] = new LogHandler[Result] {
-    def logRequest[A, T](path: List[String], argumentObject: A, result: Result[T]): Result[T] = result
+    def logRequest[A, T](path: RequestPath, argumentObject: A, result: Result[T]): Result[T] = result
   }
 }

--- a/sloth/src/main/scala/LogHandler.scala
+++ b/sloth/src/main/scala/LogHandler.scala
@@ -1,10 +1,10 @@
 package sloth
 
 trait LogHandler[Result[_]] {
-  def logRequest[A, T](endpoint: Endpoint, argumentObject: A, result: Result[T]): Result[T]
+  def logRequest[A, T](method: Method, argumentObject: A, result: Result[T]): Result[T]
 }
 object LogHandler {
   def empty[Result[_]]: LogHandler[Result] = new LogHandler[Result] {
-    def logRequest[A, T](endpoint: Endpoint, argumentObject: A, result: Result[T]): Result[T] = result
+    def logRequest[A, T](method: Method, argumentObject: A, result: Result[T]): Result[T] = result
   }
 }

--- a/sloth/src/main/scala/Request.scala
+++ b/sloth/src/main/scala/Request.scala
@@ -1,3 +1,4 @@
 package sloth
 
-case class Request[T](path: List[String], payload: T)
+case class RequestPath(apiName: String, methodName: String)
+case class Request[T](path: RequestPath, payload: T)

--- a/sloth/src/main/scala/Request.scala
+++ b/sloth/src/main/scala/Request.scala
@@ -1,17 +1,17 @@
 package sloth
 
-case class Method(apiName: String, methodName: String)
+case class Method(traitName: String, methodName: String)
 
 case class Request[T](method: Method, payload: T) {
   @deprecated("Use .method instead", "0.8.0")
-  def path: List[String] = List(method.apiName, method.methodName)
+  def path: List[String] = List(method.traitName, method.methodName)
 }
 object Request {
   @deprecated("""Use Request(Method("Api", "method"), payload) instead""", "0.8.0")
   def apply[T](path: List[String], payload: T): Request[T] = Request(methodFromList(path), payload)
 
   private[sloth] def methodFromList(path: List[String]) = path match {
-    case List(traitName, methodName) => Method(apiName = traitName, methodName = methodName)
+    case List(traitName, methodName) => Method(traitName = traitName, methodName = methodName)
     case _ => Method("", "")
   }
 }

--- a/sloth/src/main/scala/Request.scala
+++ b/sloth/src/main/scala/Request.scala
@@ -1,17 +1,17 @@
 package sloth
 
-case class Endpoint(apiName: String, methodName: String)
+case class Method(apiName: String, methodName: String)
 
-case class Request[T](endpoint: Endpoint, payload: T) {
-  @deprecated("Use .endpoint instead", "0.8.0")
-  def path: List[String] = List(endpoint.apiName, endpoint.methodName)
+case class Request[T](method: Method, payload: T) {
+  @deprecated("Use .method instead", "0.8.0")
+  def path: List[String] = List(method.apiName, method.methodName)
 }
 object Request {
-  @deprecated("""Use Request(Endpoint("Api", "method"), payload) instead""", "0.8.0")
-  def apply[T](path: List[String], payload: T): Request[T] = Request(endpointFromList(path), payload)
+  @deprecated("""Use Request(Method("Api", "method"), payload) instead""", "0.8.0")
+  def apply[T](path: List[String], payload: T): Request[T] = Request(methodFromList(path), payload)
 
-  private[sloth] def endpointFromList(path: List[String]) = path match {
-    case List(traitName, methodName) => Endpoint(apiName = traitName, methodName = methodName)
-    case _ => Endpoint("", "")
+  private[sloth] def methodFromList(path: List[String]) = path match {
+    case List(traitName, methodName) => Method(apiName = traitName, methodName = methodName)
+    case _ => Method("", "")
   }
 }

--- a/sloth/src/main/scala/Request.scala
+++ b/sloth/src/main/scala/Request.scala
@@ -1,4 +1,17 @@
 package sloth
 
-case class RequestPath(apiName: String, methodName: String)
-case class Request[T](path: RequestPath, payload: T)
+case class Endpoint(apiName: String, methodName: String)
+
+case class Request[T](endpoint: Endpoint, payload: T) {
+  @deprecated("Use .endpoint instead", "0.8.0")
+  def path: List[String] = List(endpoint.apiName, endpoint.methodName)
+}
+object Request {
+  @deprecated("""Use Request(Endpoint("Api", "method"), payload) instead""", "0.8.0")
+  def apply[T](path: List[String], payload: T): Request[T] = Request(endpointFromList(path), payload)
+
+  private[sloth] def endpointFromList(path: List[String]) = path match {
+    case List(traitName, methodName) => Endpoint(apiName = traitName, methodName = methodName)
+    case _ => Endpoint("", "")
+  }
+}

--- a/sloth/src/main/scala/Router.scala
+++ b/sloth/src/main/scala/Router.scala
@@ -7,37 +7,40 @@ import cats.implicits._
 import cats.~>
 
 trait Router[PickleType, Result[_]] {
-  val getFunction: Router.ApiMapping[PickleType, Result]
+  val get: Router.ApiMapping[PickleType, Result]
 
   def apply(request: Request[PickleType]): Either[ServerFailure, Result[PickleType]] =
-    getFunction(request.path) match {
+    get(request.endpoint) match {
       case Some(function) => function(request.payload)
-      case None => Left(ServerFailure.PathNotFound(request.path))
+      case None => Left(ServerFailure.EndpointNotFound(request.endpoint))
     }
+
+  @deprecated("Use get(endpoint) instead", "0.8.0")
+  def getFunction(path: List[String]): Option[PickleType => Either[ServerFailure, Result[PickleType]]] = get(Request.endpointFromList(path))
 
   def orElse(collect: Router.ApiMapping[PickleType, Result]): Router[PickleType, Result]
 }
 
-class RouterCo[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val getFunction: Router.ApiMapping[PickleType, Result])(implicit
+class RouterCo[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val get: Router.ApiMapping[PickleType, Result])(implicit
                                                                                                                                                        private[sloth] val functor: Functor[Result]
   ) extends Router[PickleType, Result] with PlatformSpecificRouterCo[PickleType, Result] {
 
-  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterCo[PickleType, Result] = new RouterCo(logger, request => getFunction(request).orElse(collect(request)))
+  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterCo[PickleType, Result] = new RouterCo(logger, request => get(request).orElse(collect(request)))
 
-  def mapResult[R[_]: Functor](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterCo(logger, request => getFunction(request).map { case v => v.map(_.map(f.apply)) })
+  def mapResult[R[_]: Functor](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterCo(logger, request => get(request).map { case v => v.map(_.map(f.apply)) })
 }
 
-class RouterContra[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val getFunction: Router.ApiMapping[PickleType, Result])(implicit
+class RouterContra[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val get: Router.ApiMapping[PickleType, Result])(implicit
                                                                                                                                                            private[sloth] val routerHandler: RouterContraHandler[Result]
   ) extends Router[PickleType, Result] with PlatformSpecificRouterContra[PickleType, Result] {
 
-  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterContra[PickleType, Result] = new RouterContra(logger, request => getFunction(request).orElse(collect(request)))
+  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterContra[PickleType, Result] = new RouterContra(logger, request => get(request).orElse(collect(request)))
 
-  def mapResult[R[_]: RouterContraHandler](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterContra(logger, request => getFunction(request).map { case v => v.map(_.map(f.apply)) })
+  def mapResult[R[_]: RouterContraHandler](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterContra(logger, request => get(request).map { case v => v.map(_.map(f.apply)) })
 }
 
 object Router {
-  type ApiMapping[PickleType, Result[_]] = RequestPath => Option[PickleType => Either[ServerFailure, Result[PickleType]]]
+  type ApiMapping[PickleType, Result[_]] = Endpoint => Option[PickleType => Either[ServerFailure, Result[PickleType]]]
   private val emptyApiMapping: Any => None.type = (_: Any) => None
 
   def apply[PickleType, Result[_]: Functor]: RouterCo[PickleType, Result] = apply(LogHandler.empty[Result])

--- a/sloth/src/main/scala/Router.scala
+++ b/sloth/src/main/scala/Router.scala
@@ -10,13 +10,13 @@ trait Router[PickleType, Result[_]] {
   val get: Router.ApiMapping[PickleType, Result]
 
   def apply(request: Request[PickleType]): Either[ServerFailure, Result[PickleType]] =
-    get(request.endpoint) match {
+    get(request.method) match {
       case Some(function) => function(request.payload)
-      case None => Left(ServerFailure.EndpointNotFound(request.endpoint))
+      case None => Left(ServerFailure.MethodNotFound(request.method))
     }
 
-  @deprecated("Use get(endpoint) instead", "0.8.0")
-  def getFunction(path: List[String]): Option[PickleType => Either[ServerFailure, Result[PickleType]]] = get(Request.endpointFromList(path))
+  @deprecated("Use get(method) instead", "0.8.0")
+  def getFunction(path: List[String]): Option[PickleType => Either[ServerFailure, Result[PickleType]]] = get(Request.methodFromList(path))
 
   def orElse(collect: Router.ApiMapping[PickleType, Result]): Router[PickleType, Result]
 }
@@ -40,7 +40,7 @@ class RouterContra[PickleType, Result[_]](private[sloth] val logger: LogHandler[
 }
 
 object Router {
-  type ApiMapping[PickleType, Result[_]] = Endpoint => Option[PickleType => Either[ServerFailure, Result[PickleType]]]
+  type ApiMapping[PickleType, Result[_]] = Method => Option[PickleType => Either[ServerFailure, Result[PickleType]]]
   private val emptyApiMapping: Any => None.type = (_: Any) => None
 
   def apply[PickleType, Result[_]: Functor]: RouterCo[PickleType, Result] = apply(LogHandler.empty[Result])

--- a/sloth/src/main/scala/Router.scala
+++ b/sloth/src/main/scala/Router.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import cats.~>
 
 trait Router[PickleType, Result[_]] {
-  protected def apiMap: Router.ApiMap[PickleType, Result]
+  val getFunction: Router.ApiMapping[PickleType, Result]
 
   def apply(request: Request[PickleType]): Either[ServerFailure, Result[PickleType]] =
     getFunction(request.path) match {
@@ -15,40 +15,34 @@ trait Router[PickleType, Result[_]] {
       case None => Left(ServerFailure.PathNotFound(request.path))
     }
 
-  def getFunction(path: List[String]): Option[PickleType => Either[ServerFailure, Result[PickleType]]] =
-    path match {
-      case apiName :: methodName :: Nil => apiMap.get(apiName).flatMap(_.get(methodName))
-      case _ => None
-    }
-
-  def orElse(name: String, value: Router.ApiMapValue[PickleType, Result]): Router[PickleType, Result]
+  def orElse(collect: Router.ApiMapping[PickleType, Result]): Router[PickleType, Result]
 }
 
-class RouterCo[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], protected val apiMap: Router.ApiMap[PickleType, Result])(implicit
-  private[sloth] val functor: Functor[Result]
+class RouterCo[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val getFunction: Router.ApiMapping[PickleType, Result])(implicit
+                                                                                                                                                       private[sloth] val functor: Functor[Result]
   ) extends Router[PickleType, Result] with PlatformSpecificRouterCo[PickleType, Result] {
 
-  def orElse(name: String, value: Router.ApiMapValue[PickleType, Result]): RouterCo[PickleType, Result] = new RouterCo(logger, apiMap + (name -> value))
+  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterCo[PickleType, Result] = new RouterCo(logger, request => getFunction(request).orElse(collect(request)))
 
-  def mapResult[R[_]: Functor](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterCo(logger, apiMap.map { case (k, v) => (k, v.map { case (k, v) => (k, v.map(_.map(f.apply))) }.toMap) }.toMap)
+  def mapResult[R[_]: Functor](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterCo(logger, request => getFunction(request).map { case v => v.map(_.map(f.apply)) })
 }
 
-class RouterContra[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], protected val apiMap: Router.ApiMap[PickleType, Result])(implicit
-  private[sloth] val routerHandler: RouterContraHandler[Result]
+class RouterContra[PickleType, Result[_]](private[sloth] val logger: LogHandler[Result], val getFunction: Router.ApiMapping[PickleType, Result])(implicit
+                                                                                                                                                           private[sloth] val routerHandler: RouterContraHandler[Result]
   ) extends Router[PickleType, Result] with PlatformSpecificRouterContra[PickleType, Result] {
 
-  def orElse(name: String, value: Router.ApiMapValue[PickleType, Result]): RouterContra[PickleType, Result] = new RouterContra(logger, apiMap + (name -> value))
+  def orElse(collect: Router.ApiMapping[PickleType, Result]): RouterContra[PickleType, Result] = new RouterContra(logger, request => getFunction(request).orElse(collect(request)))
 
-  def mapResult[R[_]: RouterContraHandler](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterContra(logger, apiMap.map { case (k, v) => (k, v.map { case (k, v) => (k, v.map(_.map(f.apply))) }.toMap) }.toMap)
+  def mapResult[R[_]: RouterContraHandler](f: Result ~> R, logger: LogHandler[R] = LogHandler.empty[R]): Router[PickleType, R] = new RouterContra(logger, request => getFunction(request).map { case v => v.map(_.map(f.apply)) })
 }
 
 object Router {
-  type ApiMapValue[PickleType, Result[_]] = Map[String, PickleType => Either[ServerFailure, Result[PickleType]]]
-  type ApiMap[PickleType, Result[_]] = Map[String, ApiMapValue[PickleType, Result]]
+  type ApiMapping[PickleType, Result[_]] = RequestPath => Option[PickleType => Either[ServerFailure, Result[PickleType]]]
+  private val emptyApiMapping: Any => None.type = (_: Any) => None
 
   def apply[PickleType, Result[_]: Functor]: RouterCo[PickleType, Result] = apply(LogHandler.empty[Result])
-  def apply[PickleType, Result[_]: Functor](logger: LogHandler[Result]): RouterCo[PickleType, Result] = new RouterCo[PickleType, Result](logger, Map.empty)
+  def apply[PickleType, Result[_]: Functor](logger: LogHandler[Result]): RouterCo[PickleType, Result] = new RouterCo[PickleType, Result](logger, emptyApiMapping)
 
   def contra[PickleType, Result[_]: RouterContraHandler]: RouterContra[PickleType, Result] = contra(LogHandler.empty[Result])
-  def contra[PickleType, Result[_]: RouterContraHandler](logger: LogHandler[Result]): RouterContra[PickleType, Result] = new RouterContra[PickleType, Result](logger, Map.empty)
+  def contra[PickleType, Result[_]: RouterContraHandler](logger: LogHandler[Result]): RouterContra[PickleType, Result] = new RouterContra[PickleType, Result](logger, emptyApiMapping)
 }

--- a/sloth/src/main/scala/internal/Impls.scala
+++ b/sloth/src/main/scala/internal/Impls.scala
@@ -6,7 +6,7 @@ import chameleon.{Serializer, Deserializer}
 import scala.util.{Success, Failure, Try}
 
 class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
-  def execute[T, R](path: Endpoint, arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: Method, arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializer.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -21,7 +21,7 @@ class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
 }
 
 class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, Result]) {
-  def execute[T, R](path: Endpoint, arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: Method, arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializerT.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -39,7 +39,7 @@ class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, R
 
 class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
-  def execute[T, R](path: Endpoint, arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: Method, arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializer.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {
@@ -58,7 +58,7 @@ class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
 class ClientContraImpl[PickleType, Result[_]](client: ClientContra[PickleType, Result]) {
 
-  def execute[T, R](path: Endpoint, arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: Method, arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializerT.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {

--- a/sloth/src/main/scala/internal/Impls.scala
+++ b/sloth/src/main/scala/internal/Impls.scala
@@ -6,7 +6,7 @@ import chameleon.{Serializer, Deserializer}
 import scala.util.{Success, Failure, Try}
 
 class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
-  def execute[T, R](path: List[String], arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: RequestPath, arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializer.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -21,7 +21,7 @@ class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
 }
 
 class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, Result]) {
-  def execute[T, R](path: List[String], arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: RequestPath, arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializerT.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -39,7 +39,7 @@ class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, R
 
 class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
-  def execute[T, R](path: List[String], arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: RequestPath, arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializer.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {
@@ -58,7 +58,7 @@ class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
 class ClientContraImpl[PickleType, Result[_]](client: ClientContra[PickleType, Result]) {
 
-  def execute[T, R](path: List[String], arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: RequestPath, arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializerT.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {

--- a/sloth/src/main/scala/internal/Impls.scala
+++ b/sloth/src/main/scala/internal/Impls.scala
@@ -6,7 +6,7 @@ import chameleon.{Serializer, Deserializer}
 import scala.util.{Success, Failure, Try}
 
 class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
-  def execute[T, R](path: RequestPath, arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: Endpoint, arguments: PickleType)(call: T => Result[R])(implicit deserializer: Deserializer[T, PickleType], serializer: Serializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializer.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -21,7 +21,7 @@ class RouterImpl[PickleType, Result[_]](router: RouterCo[PickleType, Result]) {
 }
 
 class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, Result]) {
-  def execute[T, R](path: RequestPath, arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
+  def execute[T, R](path: Endpoint, arguments: PickleType)(call: T => Result[R])(implicit deserializerT: Deserializer[T, PickleType], deserializerR: Deserializer[R, PickleType]): Either[ServerFailure, Result[PickleType]] = {
     deserializerT.deserialize(arguments) match {
       case Right(arguments) =>
         Try(call(arguments)) match {
@@ -39,7 +39,7 @@ class RouterContraImpl[PickleType, Result[_]](router: RouterContra[PickleType, R
 
 class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
-  def execute[T, R](path: RequestPath, arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: Endpoint, arguments: T)(implicit deserializer: Deserializer[R, PickleType], serializer: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializer.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {
@@ -58,7 +58,7 @@ class ClientImpl[PickleType, Result[_]](client: ClientCo[PickleType, Result]) {
 
 class ClientContraImpl[PickleType, Result[_]](client: ClientContra[PickleType, Result]) {
 
-  def execute[T, R](path: RequestPath, arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
+  def execute[T, R](path: Endpoint, arguments: T)(implicit serializerR: Serializer[R, PickleType], serializerT: Serializer[T, PickleType]): Result[R] = {
     val serializedArguments = serializerT.serialize(arguments)
     val request: Request[PickleType] = Request(path, serializedArguments)
     val result: Result[R] = Try(client.transport(request)) match {

--- a/sloth/src/main/scala/package.scala
+++ b/sloth/src/main/scala/package.scala
@@ -1,0 +1,4 @@
+package object sloth {
+  @deprecated("Use EndpointName instead", "0.8.0")
+  type PathName = EndpointName
+}

--- a/sloth/src/main/scala/package.scala
+++ b/sloth/src/main/scala/package.scala
@@ -1,4 +1,4 @@
 package object sloth {
-  @deprecated("Use EndpointName instead", "0.8.0")
-  type PathName = EndpointName
+  @deprecated("Use Name instead", "0.8.0")
+  type PathName = Name
 }

--- a/sloth/src/test/scala/ImplsSpec.scala
+++ b/sloth/src/test/scala/ImplsSpec.scala
@@ -21,7 +21,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val resultValue = "\"Argument(1)\""
-      val result = impl.execute[Argument, String](Nil, pickledInput)(_.toString)
+      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_.toString)
 
       result mustEqual Right(resultValue)
     }
@@ -33,7 +33,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](Nil, pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -51,7 +51,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
 
       val receivedParameters = collection.mutable.ArrayBuffer.empty[Argument]
       val receivedStrings = collection.mutable.ArrayBuffer.empty[String]
-      val result = impl.execute[Argument, String](Nil, pickledInput) { argument =>
+      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput) { argument =>
         receivedParameters += argument
 
         { string =>
@@ -73,7 +73,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](Nil, pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -90,7 +90,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Argument]("api" :: "f" :: Nil, argument)
+      val result = impl.execute[Argument, Argument](RequestPath("api", "f"), argument)
 
       result mustEqual Right(argument)
     }
@@ -102,7 +102,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Double]("api" :: "f" :: Nil, argument)
+      val result = impl.execute[Argument, Double](RequestPath("api", "f"), argument)
 
       result mustEqual Left(ClientFailure.TransportError(exception))
     }
@@ -125,7 +125,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Argument]("api" :: "f" :: Nil, argument)
+      val resultf = impl.execute[Argument, Argument](RequestPath("api", "f"), argument)
 
       resultf(Argument(2)) mustEqual Right(())
 
@@ -140,7 +140,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Double]("api" :: "f" :: Nil, argument)
+      val resultf = impl.execute[Argument, Double](RequestPath("api", "f"), argument)
 
       resultf(2.0) mustEqual Left(ClientFailure.TransportError(exception))
     }

--- a/sloth/src/test/scala/ImplsSpec.scala
+++ b/sloth/src/test/scala/ImplsSpec.scala
@@ -21,7 +21,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val resultValue = "\"Argument(1)\""
-      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_.toString)
+      val result = impl.execute[Argument, String](Method("eine", "methode"), pickledInput)(_.toString)
 
       result mustEqual Right(resultValue)
     }
@@ -33,7 +33,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](Method("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -51,7 +51,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
 
       val receivedParameters = collection.mutable.ArrayBuffer.empty[Argument]
       val receivedStrings = collection.mutable.ArrayBuffer.empty[String]
-      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput) { argument =>
+      val result = impl.execute[Argument, String](Method("eine", "methode"), pickledInput) { argument =>
         receivedParameters += argument
 
         { string =>
@@ -73,7 +73,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](Method("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -90,7 +90,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Argument](Endpoint("api", "f"), argument)
+      val result = impl.execute[Argument, Argument](Method("api", "f"), argument)
 
       result mustEqual Right(argument)
     }
@@ -102,7 +102,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Double](Endpoint("api", "f"), argument)
+      val result = impl.execute[Argument, Double](Method("api", "f"), argument)
 
       result mustEqual Left(ClientFailure.TransportError(exception))
     }
@@ -125,7 +125,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Argument](Endpoint("api", "f"), argument)
+      val resultf = impl.execute[Argument, Argument](Method("api", "f"), argument)
 
       resultf(Argument(2)) mustEqual Right(())
 
@@ -140,7 +140,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Double](Endpoint("api", "f"), argument)
+      val resultf = impl.execute[Argument, Double](Method("api", "f"), argument)
 
       resultf(2.0) mustEqual Left(ClientFailure.TransportError(exception))
     }

--- a/sloth/src/test/scala/ImplsSpec.scala
+++ b/sloth/src/test/scala/ImplsSpec.scala
@@ -21,7 +21,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val resultValue = "\"Argument(1)\""
-      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_.toString)
+      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_.toString)
 
       result mustEqual Right(resultValue)
     }
@@ -33,7 +33,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -51,7 +51,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
 
       val receivedParameters = collection.mutable.ArrayBuffer.empty[Argument]
       val receivedStrings = collection.mutable.ArrayBuffer.empty[String]
-      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput) { argument =>
+      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput) { argument =>
         receivedParameters += argument
 
         { string =>
@@ -73,7 +73,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val argument = Argument(1)
       val pickledInput = Serializer[Argument, PickleType].serialize(argument)
       val exception = new Exception("meh")
-      val result = impl.execute[Argument, String](RequestPath("eine", "methode"), pickledInput)(_ => throw exception)
+      val result = impl.execute[Argument, String](Endpoint("eine", "methode"), pickledInput)(_ => throw exception)
 
       result mustEqual Left(ServerFailure.HandlerError(exception))
     }
@@ -90,7 +90,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Argument](RequestPath("api", "f"), argument)
+      val result = impl.execute[Argument, Argument](Endpoint("api", "f"), argument)
 
       result mustEqual Right(argument)
     }
@@ -102,7 +102,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientImpl(client)
 
       val argument = Argument(1)
-      val result = impl.execute[Argument, Double](RequestPath("api", "f"), argument)
+      val result = impl.execute[Argument, Double](Endpoint("api", "f"), argument)
 
       result mustEqual Left(ClientFailure.TransportError(exception))
     }
@@ -125,7 +125,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Argument](RequestPath("api", "f"), argument)
+      val resultf = impl.execute[Argument, Argument](Endpoint("api", "f"), argument)
 
       resultf(Argument(2)) mustEqual Right(())
 
@@ -140,7 +140,7 @@ class ImplsSpec extends AnyFreeSpec with Matchers {
       val impl = new ClientContraImpl(client)
 
       val argument = Argument(1)
-      val resultf = impl.execute[Argument, Double](RequestPath("api", "f"), argument)
+      val resultf = impl.execute[Argument, Double](Endpoint("api", "f"), argument)
 
       resultf(2.0) mustEqual Left(ClientFailure.TransportError(exception))
     }

--- a/sloth/src/test/scala/SlothSpec.scala
+++ b/sloth/src/test/scala/SlothSpec.scala
@@ -23,7 +23,7 @@ trait SingleApi {
   // def bum(a: Int): Option[Int]
   // should not compile because of generic parameter
   // def bom[T](a: T): Future[Int]
-  @EndpointName("kanone") // does not compile without EndpointName, because overloaded
+  @Name("kanone") // does not compile without MethodName, because overloaded
   def foo: Future[Int]
 }
 object SingleApiImpl extends SingleApi {

--- a/sloth/src/test/scala/SlothSpec.scala
+++ b/sloth/src/test/scala/SlothSpec.scala
@@ -23,7 +23,7 @@ trait SingleApi {
   // def bum(a: Int): Option[Int]
   // should not compile because of generic parameter
   // def bom[T](a: T): Future[Int]
-  @PathName("kanone") // does not compile without PathName, because overloaded
+  @EndpointName("kanone") // does not compile without EndpointName, because overloaded
   def foo: Future[Int]
 }
 object SingleApiImpl extends SingleApi {

--- a/sloth/src/test/scala/SlothSpec.scala
+++ b/sloth/src/test/scala/SlothSpec.scala
@@ -23,7 +23,7 @@ trait SingleApi {
   // def bum(a: Int): Option[Int]
   // should not compile because of generic parameter
   // def bom[T](a: T): Future[Int]
-  @Name("kanone") // does not compile without MethodName, because overloaded
+  @Name("kanone") // does not compile without Name annotation, because overloaded
   def foo: Future[Int]
 }
 object SingleApiImpl extends SingleApi {


### PR DESCRIPTION
This makes the Router#route macro generate more efficient code.

We now generate a direct string comparison for mapping the request to the right implementation, instead of a HashMap. An example macro expansion looks like this:
```scala
val value = ApiImplFunResponse;
val implRouter = sloth.Router.apply[test.PickleType, test.TypeHelper.ApiResultFun](TypeHelper.functor(SlothSpec.this.executionContext));
val impl = new _root_.sloth.internal.RouterImpl[test.PickleType, test.TypeHelper.ApiResultFun](implRouter);
implRouter.orElse(((endpoint) =>
    if (endpoint.traitName.$eq$eq("Api"))
        endpoint.methodName match {
            case "fun" => Some(((payload: test.PickleType) => impl.execute[scala.Tuple2[Int, String], Int](endpoint, payload)(((args) => value.fun(args._1, args._2)))))
            case "multi" => Some(((payload: test.PickleType) => impl.execute[scala.Tuple2[Int, Int], Int](endpoint, payload)(((args) => value.multi(args._1)(args._2)))))
            case _ => None
        }
    else None
))
```

We are also changing the reoccuring type `path: List[String]` to `Method`, which consists of the traitName and the methodName. We have added deprecated aliases for easier migration, it allows to work `List[String]` (now `Method`), `PathName` (now `Name`), `PathNotFound` (now `MethodNotFound`). These will be removed in the upcoming 1.0 release.
