### PR TITLE
Fix request url for jsdomClient

### DIFF
--- a/jsdomClient/src/main/scala/HttpRpcTransport.scala
+++ b/jsdomClient/src/main/scala/HttpRpcTransport.scala
@@ -19,7 +19,7 @@ object HttpRpcTransport {
   def apply[F[_]: Async](config: F[HttpRequestConfig]): RequestTransport[String, F] = new RequestTransport[String, F] {
     override def apply(request: Request[String]): F[String] = for {
       config <- config
-      url = s"${config.baseUri}/${request.method.traitName}/${request.method.methodName}"
+      url = s"${config.baseUri}${request.method.traitName}/${request.method.methodName}"
       requestArgs = new dom.RequestInit { headers = config.headers.toJSDictionary; method = dom.HttpMethod.POST; body = request.payload }
       result <- Async[F].fromThenable(Async[F].delay[js.Thenable[String]](dom.fetch(url, requestArgs).`then`[String](_.text())))
     } yield result


### PR DESCRIPTION
The `/` is already contained in `baseUri`.